### PR TITLE
Added missing line break after a code block in code.md

### DIFF
--- a/ru/syntax/code.md
+++ b/ru/syntax/code.md
@@ -33,4 +33,5 @@
   variant= 'detailed' 
 ```
 ```
+
 Ознакомиться с перечнем доступных языков можно в [Github](https://github.com/highlightjs/highlight.js/tree/master/src/languages). О том, как передать дополнительный набор языков, смотрите в разделе [Подключить дополнительный язык](../tools/transform/highlight.md#add).


### PR DESCRIPTION
A line break was missing before a regular paragraph. As a result, on the documentation portal, the paragraph was rendered as a code block which it is not.

![image](https://github.com/user-attachments/assets/f5ac1789-73d3-4f68-a3ce-973ee8f4a407)
