### PR TITLE
Document image captions support

### DIFF
--- a/en/syntax/media.md
+++ b/en/syntax/media.md
@@ -14,16 +14,33 @@ The standard markup for inserting an image is:
 ![alt-text](_images/image.png "hint_text" =100x100)
 ```
 
-  * `alt-text`: Alternative image text.
-  * `_images/image.png`: The URL or path to the image file.
-  * `"hint_text"`: A hint that will be displayed when you hover over the image. Optional.
-  * `=100x100`: The image size. Optional.
+* `alt-text`: Alternative image text.
+* `_images/image.png`: The URL or path to the image file.
+* `"hint_text"`: A hint that will be displayed when you hover over the image. Optional.
+* `=100x100`: The image size. Optional.
 
-    {% note tip %}
+  {% note tip %}
 
-    If you want to keep the aspect ratio of your image, only specify its width: `100x`.
+  If you want to keep the aspect ratio of your image, only specify its width: `100x`.
 
-    {% endnote %}
+  {% endnote %}
+
+### Images with captions
+
+You can enable the display of the caption you need to add the { caption } as attribute, the default value is equal to the title, but it can also be passed in the attribute.
+
+```markdown
+![Alt text](../../_images/mountain.jpg "Default caption text" =100x100){ caption }
+
+![Alt text](../../_images/mountain.jpg "Title" =100x100){ caption="Specified caption text" }
+```
+
+**Result**
+
+![Alt text](../../_images/mountain.jpg "Default caption text" =100x100){ caption }
+
+![Alt text](../../_images/mountain.jpg "Title" =100x100){ caption="Specified caption text" }
+
 
 ### Images as links {#image-link}
 
@@ -61,4 +78,3 @@ To add videos to a page, use markup:
 ```
 
 To review the style options and list of available video hosting services, see the [markdown-it-video](https://www.npmjs.com/package/markdown-it-video) plugin page.
-


### PR DESCRIPTION
Documents [Add image captions support](https://github.com/diplodoc-platform/transform/pull/586).


## Example Syntax
```md
![Alt text](_images/image.png "Caption text" =100x100){ caption }
```
In this example, the "Caption text" should be rendered within a figcaption tag below the image.

## Example HTML Output
The resulting HTML should look like this:
```html
<figure>
    <img src="_images/image.png" alt="Alt text" width="100" height="100" title="Caption text">
    <figcaption>Caption text</figcaption>
</figure>
```
DOCSTOOLS-3428

Related issue: https://github.com/diplodoc-platform/transform/issues/514