### PR TITLE
FIx typo in quick start for developers

### DIFF
--- a/ru/dev/quickstart.md
+++ b/ru/dev/quickstart.md
@@ -1,6 +1,6 @@
 # Быстрый старт
 
-Платформа diplodoc разрабатывается на осноне набора независимых модулей, расположенных в GitHub организации [diplodoc-platform](https://github.com/diplodoc-platform).
+Платформа diplodoc разрабатывается на основе набора независимых модулей, расположенных в GitHub организации [diplodoc-platform](https://github.com/diplodoc-platform).
 
 Каждый модуль можно разрабатывать как по отдельности, так и в составе [метапакета](./metapackage.md).
 


### PR DESCRIPTION
### Motivation

There is a typo on the page https://diplodoc.com/docs/ru/dev/quickstart in word `осноне` in the first paragraph.

### Changes description

This PR changes the word `осноне` to `основе`.