### PR TITLE
docs: document --build-stats flag and yfm-build-stats.json format

### DIFF
--- a/en/tools/docs/build.md
+++ b/en/tools/docs/build.md
@@ -74,10 +74,3 @@ Example output:
   }
 }
 ```
-
-Typical use cases:
-
-* track `durationMs`, `phasesMs` and `memoryUsageMb` across builds to catch slowdowns and memory regressions;
-* monitor `output.totalBytes` and `output.bytesByExtension` to spot accidentally committed heavy assets;
-* fail CI on `counters.graph.missed > 0` or `counters.errors > 0` as a broken-build signal;
-* compare `counters.entriesPlanned` against `counters.entriesProcessed` — a mismatch means some pages failed mid-build.

--- a/en/tools/docs/build.md
+++ b/en/tools/docs/build.md
@@ -28,3 +28,56 @@ Building in YFM allows you to use:
 * [Variable substitutions](../../syntax/vars.md#subtitudes) if the `apply-presets` parameter is specified.
 
 Use this type of build to support multiple document versions for different users. For example, if there are sections with internal information in the documentation, you can keep two repositories: private and public, and synchronize private with public using conditions.
+
+## Build stats {#build-stats}
+
+When started with [`--build-stats`](settings.md) (or `buildStats: true` in the [configuration file](../../project/config.md)), a `yfm-build-stats.json` file is written next to the output with metrics for the current build. The file is intended for CI dashboards, regression tracking and diagnostics — runtime doesn't need it.
+
+What goes in:
+
+* `cli` — package version, Node version, platform, architecture, OS release.
+* `build` — `startedAt`, `finishedAt`, `durationMs`, a coarse phase split `phasesMs.{prepare, entries, finalize}` derived from `Entry`-hook timestamps, plus `outputFormat`, `langs`, `inputDir`, `outputDir`, `configHash` (sha256 over a stably-serialized config), `features` (enabled boolean flags) and `worker.maxOldSpace`.
+* `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, breakdowns `entriesByExtension` and `entriesByLang`, `headings` and `contentBytes` (for markdown entries), plus `graph.{entries, sources, resources, missed, edges}` — a snapshot of the dependency graph: pages, included files, assets, missing paths and total edge count.
+* `output` — `files`, `totalBytes`, `bytesByExtension`, `largestFile`.
+* `schemaVersion` — format version. Additive changes keep the schema backward compatible; breaking changes will bump this number.
+
+Example output:
+
+```json
+{
+  "schemaVersion": 1,
+  "cli": { "version": "5.29.0", "node": "v22.22.0", "platform": "darwin", "arch": "arm64" },
+  "build": {
+    "durationMs": 990,
+    "phasesMs": { "prepare": 951, "entries": 16, "finalize": 23 },
+    "outputFormat": "html",
+    "langs": ["en", "ru"],
+    "configHash": "6a5891269cbab2b5",
+    "features": ["addAlternateMeta", "allowHtml", "buildStats", "sanitizeHtml"]
+  },
+  "counters": {
+    "tocs": 3,
+    "entriesPlanned": 130,
+    "entriesProcessed": 130,
+    "entriesByExtension": { ".md": 119, ".yaml": 11 },
+    "entriesByLang": { "ru": 88, "en": 42 },
+    "headings": 338,
+    "contentBytes": 1596875,
+    "graph": { "entries": 128, "sources": 11, "resources": 69, "missed": 0, "edges": 118 },
+    "warnings": 0,
+    "errors": 0
+  },
+  "output": {
+    "files": 403,
+    "totalBytes": 42513143,
+    "largestFile": { "path": "ru/_images/highload.png", "bytes": 5436055 }
+  }
+}
+```
+
+Typical use cases:
+
+* track `durationMs` and `phasesMs` across builds to catch slowdowns;
+* monitor `output.totalBytes` and `output.largestFile` to spot accidentally committed heavy assets;
+* fail CI on `counters.graph.missed > 0` or `counters.errors > 0` as a broken-build signal;
+* keep `build.configHash` alongside published artifacts so you know which exact config produced them.

--- a/en/tools/docs/build.md
+++ b/en/tools/docs/build.md
@@ -36,9 +36,9 @@ When started with [`--build-stats`](settings.md) (or `buildStats: true` in the [
 What goes in:
 
 * `cli` — package version, Node version, platform, architecture, OS release.
-* `build` — `startedAt`, `finishedAt`, `durationMs`, a coarse phase split `phasesMs.{prepare, entries, finalize}` derived from `Entry`-hook timestamps, plus `outputFormat`, `langs`, `inputDir`, `outputDir`, `configHash` (sha256 over a stably-serialized config), `features` (enabled boolean flags) and `worker.maxOldSpace`.
+* `build` — `startedAt`, `finishedAt`, `durationMs`, a coarse phase split `phasesMs.{prepare, entries, finalize}` derived from `Entry`-hook timestamps, plus `outputFormat`, `langs`, `inputDir`, `outputDir`, `features` (enabled boolean flags), `memoryUsageMb` (`heapUsed` snapshot at finish, in MB) and `worker.maxOldSpace`.
 * `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, breakdowns `entriesByExtension` and `entriesByLang`, `headings` and `contentBytes` (for markdown entries), plus `graph.{entries, sources, resources, missed, edges}` — a snapshot of the dependency graph: pages, included files, assets, missing paths and total edge count.
-* `output` — `files`, `totalBytes`, `bytesByExtension`, `largestFile`.
+* `output` — `files`, `totalBytes`, `bytesByExtension`.
 * `schemaVersion` — format version. Additive changes keep the schema backward compatible; breaking changes will bump this number.
 
 Example output:
@@ -48,36 +48,36 @@ Example output:
   "schemaVersion": 1,
   "cli": { "version": "5.29.0", "node": "v22.22.0", "platform": "darwin", "arch": "arm64" },
   "build": {
-    "durationMs": 990,
-    "phasesMs": { "prepare": 951, "entries": 16, "finalize": 23 },
+    "durationMs": 1474,
+    "phasesMs": { "prepare": 1242, "entries": 148, "finalize": 84 },
     "outputFormat": "html",
-    "langs": ["en", "ru"],
-    "configHash": "6a5891269cbab2b5",
-    "features": ["addAlternateMeta", "allowHtml", "buildStats", "sanitizeHtml"]
+    "langs": ["ru", "en"],
+    "features": ["addAlternateMeta", "allowHtml", "buildStats", "sanitizeHtml"],
+    "memoryUsageMb": 256
   },
   "counters": {
     "tocs": 3,
-    "entriesPlanned": 130,
-    "entriesProcessed": 130,
-    "entriesByExtension": { ".md": 119, ".yaml": 11 },
-    "entriesByLang": { "ru": 88, "en": 42 },
-    "headings": 338,
-    "contentBytes": 1596875,
-    "graph": { "entries": 128, "sources": 11, "resources": 69, "missed": 0, "edges": 118 },
+    "entriesPlanned": 133,
+    "entriesProcessed": 133,
+    "entriesByExtension": { ".md": 122, ".yaml": 11 },
+    "entriesByLang": { "ru": 91, "en": 42 },
+    "headings": 345,
+    "contentBytes": 1693771,
+    "graph": { "entries": 130, "sources": 12, "resources": 74, "missed": 0, "edges": 129 },
     "warnings": 0,
     "errors": 0
   },
   "output": {
-    "files": 403,
-    "totalBytes": 42513143,
-    "largestFile": { "path": "ru/_images/highload.png", "bytes": 5436055 }
+    "files": 421,
+    "totalBytes": 45350699,
+    "bytesByExtension": { ".html": 2865454, ".js": 9721257, ".png": 24588860 }
   }
 }
 ```
 
 Typical use cases:
 
-* track `durationMs` and `phasesMs` across builds to catch slowdowns;
-* monitor `output.totalBytes` and `output.largestFile` to spot accidentally committed heavy assets;
+* track `durationMs`, `phasesMs` and `memoryUsageMb` across builds to catch slowdowns and memory regressions;
+* monitor `output.totalBytes` and `output.bytesByExtension` to spot accidentally committed heavy assets;
 * fail CI on `counters.graph.missed > 0` or `counters.errors > 0` as a broken-build signal;
-* keep `build.configHash` alongside published artifacts so you know which exact config produced them.
+* compare `counters.entriesPlanned` against `counters.entriesProcessed` — a mismatch means some pages failed mid-build.

--- a/en/tools/docs/build.md
+++ b/en/tools/docs/build.md
@@ -37,7 +37,7 @@ What goes in:
 
 * `cli` — package version, Node version, platform, architecture, OS release.
 * `build` — `startedAt`, `finishedAt`, `durationMs`, a coarse phase split `phasesMs.{prepare, entries, finalize}` derived from `Entry`-hook timestamps, plus `outputFormat`, `langs`, `inputDir`, `outputDir`, `features` (enabled boolean flags), `memoryUsageMb` (`heapUsed` snapshot at finish, in MB) and `worker.maxOldSpace`.
-* `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, breakdowns `entriesByExtension` and `entriesByLang`, `headings` and `contentBytes` (for markdown entries), plus `graph.{entries, sources, resources, missed, edges}` — a snapshot of the dependency graph: pages, included files, assets, missing paths and total edge count.
+* `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, breakdowns `entriesByExtension` and `entriesByLang`, `headings` and `contentBytes` (for markdown entries), `graph.{entries, sources, resources, missed, edges}` — a snapshot of the dependency graph (pages, included files, assets, missing paths and total edge count), plus `warnings` / `errors` (totals) and `warningsByCode` / `errorsByCode` — per-YFM-code breakdown (`YFM013`, `YFM016`, etc.); messages without a recognizable code fall into the `(uncoded)` bucket.
 * `output` — `files`, `totalBytes`, `bytesByExtension`.
 * `schemaVersion` — format version. Additive changes keep the schema backward compatible; breaking changes will bump this number.
 
@@ -64,8 +64,10 @@ Example output:
     "headings": 345,
     "contentBytes": 1693771,
     "graph": { "entries": 130, "sources": 12, "resources": 74, "missed": 0, "edges": 129 },
-    "warnings": 0,
-    "errors": 0
+    "warnings": 3,
+    "errors": 1,
+    "warningsByCode": { "YFM013": 2, "(uncoded)": 1 },
+    "errorsByCode": { "YFM016": 1 }
   },
   "output": {
     "files": 421,

--- a/en/tools/docs/settings.md
+++ b/en/tools/docs/settings.md
@@ -25,5 +25,6 @@ The name of the startup key corresponds to the name of the setting.
 | `--lint-disabled`           | Should whether to turn off a linter |
 | `--build-disabled`          | Should whether to turn off a build |
 | `--add-map-file`            | Should add all paths of documentation into file.json. Disabled by default. |
+| `--build-stats`             | Write a `yfm-build-stats.json` file next to the output with build metrics (duration, page and asset counters, output size). See [Build stats](build.md#build-stats) for the full schema. Disabled by default. |
 
 To view the full list of keys, run the `yfm --help` command.

--- a/ru/tools/docs/build.md
+++ b/ru/tools/docs/build.md
@@ -87,10 +87,3 @@ yfm -o ./output-folder
   }
 }
 ```
-
-Типичные сценарии использования:
-
-* отслеживать `durationMs`, `phasesMs` и `memoryUsageMb` от сборки к сборке, чтобы поймать замедления и резкий рост потребления памяти;
-* мониторить `output.totalBytes` и `output.bytesByExtension`, чтобы заметить случайно залитые тяжёлые ассеты;
-* проверять `counters.graph.missed` и `counters.errors` в CI как сигнал о битых ссылках или сломанной сборке;
-* сравнивать `counters.entriesPlanned` и `counters.entriesProcessed` — расхождение указывает на сбой обработки части страниц.

--- a/ru/tools/docs/build.md
+++ b/ru/tools/docs/build.md
@@ -41,3 +41,56 @@ yfm -o ./output-folder
 Вы можете автоматизировать пересборку отдельных статей при их изменении. Для этого вызовите `yfm build` с параметром `--watch`: после сборки проекта программа перейдёт в режим инкрементальной пересборки и будет создавать или обновлять статьи после сохранения изменений в исходных файлах документации.
 
 Для удобства, после пересборки открытого в браузере файла выполняется автоматическая перезагрузка страницы.
+
+## Статистика сборки {#build-stats}
+
+При запуске с ключом [`--build-stats`](settings.md#build-stats-flag) (или `buildStats: true` в [файле конфигурации](../../settings.md#config)) рядом с output записывается файл `yfm-build-stats.json` с метриками текущей сборки. Файл предназначен для CI-дашбордов, отслеживания регрессий и диагностики — для рантайма он не нужен.
+
+Что попадает в файл:
+
+* `cli` — версия пакета, версия Node, платформа, архитектура, релиз ОС.
+* `build` — `startedAt`, `finishedAt`, `durationMs`, грубое разбиение по фазам `phasesMs.{prepare, entries, finalize}` (на основе времени `Entry`-хука), `outputFormat`, `langs`, `inputDir`, `outputDir`, `configHash` (sha256 от стабильно сериализованного конфига), `features` (включённые булевы флаги), `worker.maxOldSpace`.
+* `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, разбивки `entriesByExtension` и `entriesByLang`, `headings` и `contentBytes` (для md-страниц), а также `graph.{entries, sources, resources, missed, edges}` — снимок графа зависимостей: страницы, включаемые файлы, ассеты, отсутствующие пути и число рёбер.
+* `output` — `files`, `totalBytes`, `bytesByExtension`, `largestFile`.
+* `schemaVersion` — версия формата файла. При расширении формата схема будет совместимой; ломающие изменения увеличат это число.
+
+Пример выходного файла:
+
+```json
+{
+  "schemaVersion": 1,
+  "cli": { "version": "5.29.0", "node": "v22.22.0", "platform": "darwin", "arch": "arm64" },
+  "build": {
+    "durationMs": 990,
+    "phasesMs": { "prepare": 951, "entries": 16, "finalize": 23 },
+    "outputFormat": "html",
+    "langs": ["en", "ru"],
+    "configHash": "6a5891269cbab2b5",
+    "features": ["addAlternateMeta", "allowHtml", "buildStats", "sanitizeHtml"]
+  },
+  "counters": {
+    "tocs": 3,
+    "entriesPlanned": 130,
+    "entriesProcessed": 130,
+    "entriesByExtension": { ".md": 119, ".yaml": 11 },
+    "entriesByLang": { "ru": 88, "en": 42 },
+    "headings": 338,
+    "contentBytes": 1596875,
+    "graph": { "entries": 128, "sources": 11, "resources": 69, "missed": 0, "edges": 118 },
+    "warnings": 0,
+    "errors": 0
+  },
+  "output": {
+    "files": 403,
+    "totalBytes": 42513143,
+    "largestFile": { "path": "ru/_images/highload.png", "bytes": 5436055 }
+  }
+}
+```
+
+Типичные сценарии использования:
+
+* отслеживать `durationMs` и `phasesMs` от сборки к сборке, чтобы поймать замедления;
+* мониторить `output.totalBytes` и `output.largestFile`, чтобы заметить случайно залитые тяжёлые ассеты;
+* проверять `counters.graph.missed` и `counters.errors` в CI как сигнал о битых ссылках или сломанной сборке;
+* сохранять `build.configHash` рядом с артефактами, чтобы знать, какой именно конфиг использовался.

--- a/ru/tools/docs/build.md
+++ b/ru/tools/docs/build.md
@@ -50,7 +50,7 @@ yfm -o ./output-folder
 
 * `cli` — версия пакета, версия Node, платформа, архитектура, релиз ОС.
 * `build` — `startedAt`, `finishedAt`, `durationMs`, грубое разбиение по фазам `phasesMs.{prepare, entries, finalize}` (на основе времени `Entry`-хука), `outputFormat`, `langs`, `inputDir`, `outputDir`, `features` (включённые булевы флаги), `memoryUsageMb` (`heapUsed` в момент завершения, в МБ), `worker.maxOldSpace`.
-* `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, разбивки `entriesByExtension` и `entriesByLang`, `headings` и `contentBytes` (для md-страниц), а также `graph.{entries, sources, resources, missed, edges}` — снимок графа зависимостей: страницы, включаемые файлы, ассеты, отсутствующие пути и число рёбер.
+* `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, разбивки `entriesByExtension` и `entriesByLang`, `headings` и `contentBytes` (для md-страниц), `graph.{entries, sources, resources, missed, edges}` — снимок графа зависимостей (страницы, включаемые файлы, ассеты, отсутствующие пути, число рёбер), а также `warnings` / `errors` (общее число) и `warningsByCode` / `errorsByCode` — разбивка по кодам ошибок (`YFM013`, `YFM016` и т.п.; сообщения без распознанного кода попадают в бакет `(uncoded)`).
 * `output` — `files`, `totalBytes`, `bytesByExtension`.
 * `schemaVersion` — версия формата файла. При расширении формата схема будет совместимой; ломающие изменения увеличат это число.
 
@@ -77,8 +77,10 @@ yfm -o ./output-folder
     "headings": 345,
     "contentBytes": 1693771,
     "graph": { "entries": 130, "sources": 12, "resources": 74, "missed": 0, "edges": 129 },
-    "warnings": 0,
-    "errors": 0
+    "warnings": 3,
+    "errors": 1,
+    "warningsByCode": { "YFM013": 2, "(uncoded)": 1 },
+    "errorsByCode": { "YFM016": 1 }
   },
   "output": {
     "files": 421,

--- a/ru/tools/docs/build.md
+++ b/ru/tools/docs/build.md
@@ -49,9 +49,9 @@ yfm -o ./output-folder
 Что попадает в файл:
 
 * `cli` — версия пакета, версия Node, платформа, архитектура, релиз ОС.
-* `build` — `startedAt`, `finishedAt`, `durationMs`, грубое разбиение по фазам `phasesMs.{prepare, entries, finalize}` (на основе времени `Entry`-хука), `outputFormat`, `langs`, `inputDir`, `outputDir`, `configHash` (sha256 от стабильно сериализованного конфига), `features` (включённые булевы флаги), `worker.maxOldSpace`.
+* `build` — `startedAt`, `finishedAt`, `durationMs`, грубое разбиение по фазам `phasesMs.{prepare, entries, finalize}` (на основе времени `Entry`-хука), `outputFormat`, `langs`, `inputDir`, `outputDir`, `features` (включённые булевы флаги), `memoryUsageMb` (`heapUsed` в момент завершения, в МБ), `worker.maxOldSpace`.
 * `counters` — `tocs`, `entriesPlanned` / `entriesProcessed`, разбивки `entriesByExtension` и `entriesByLang`, `headings` и `contentBytes` (для md-страниц), а также `graph.{entries, sources, resources, missed, edges}` — снимок графа зависимостей: страницы, включаемые файлы, ассеты, отсутствующие пути и число рёбер.
-* `output` — `files`, `totalBytes`, `bytesByExtension`, `largestFile`.
+* `output` — `files`, `totalBytes`, `bytesByExtension`.
 * `schemaVersion` — версия формата файла. При расширении формата схема будет совместимой; ломающие изменения увеличат это число.
 
 Пример выходного файла:
@@ -61,36 +61,36 @@ yfm -o ./output-folder
   "schemaVersion": 1,
   "cli": { "version": "5.29.0", "node": "v22.22.0", "platform": "darwin", "arch": "arm64" },
   "build": {
-    "durationMs": 990,
-    "phasesMs": { "prepare": 951, "entries": 16, "finalize": 23 },
+    "durationMs": 1474,
+    "phasesMs": { "prepare": 1242, "entries": 148, "finalize": 84 },
     "outputFormat": "html",
-    "langs": ["en", "ru"],
-    "configHash": "6a5891269cbab2b5",
-    "features": ["addAlternateMeta", "allowHtml", "buildStats", "sanitizeHtml"]
+    "langs": ["ru", "en"],
+    "features": ["addAlternateMeta", "allowHtml", "buildStats", "sanitizeHtml"],
+    "memoryUsageMb": 256
   },
   "counters": {
     "tocs": 3,
-    "entriesPlanned": 130,
-    "entriesProcessed": 130,
-    "entriesByExtension": { ".md": 119, ".yaml": 11 },
-    "entriesByLang": { "ru": 88, "en": 42 },
-    "headings": 338,
-    "contentBytes": 1596875,
-    "graph": { "entries": 128, "sources": 11, "resources": 69, "missed": 0, "edges": 118 },
+    "entriesPlanned": 133,
+    "entriesProcessed": 133,
+    "entriesByExtension": { ".md": 122, ".yaml": 11 },
+    "entriesByLang": { "ru": 91, "en": 42 },
+    "headings": 345,
+    "contentBytes": 1693771,
+    "graph": { "entries": 130, "sources": 12, "resources": 74, "missed": 0, "edges": 129 },
     "warnings": 0,
     "errors": 0
   },
   "output": {
-    "files": 403,
-    "totalBytes": 42513143,
-    "largestFile": { "path": "ru/_images/highload.png", "bytes": 5436055 }
+    "files": 421,
+    "totalBytes": 45350699,
+    "bytesByExtension": { ".html": 2865454, ".js": 9721257, ".png": 24588860 }
   }
 }
 ```
 
 Типичные сценарии использования:
 
-* отслеживать `durationMs` и `phasesMs` от сборки к сборке, чтобы поймать замедления;
-* мониторить `output.totalBytes` и `output.largestFile`, чтобы заметить случайно залитые тяжёлые ассеты;
+* отслеживать `durationMs`, `phasesMs` и `memoryUsageMb` от сборки к сборке, чтобы поймать замедления и резкий рост потребления памяти;
+* мониторить `output.totalBytes` и `output.bytesByExtension`, чтобы заметить случайно залитые тяжёлые ассеты;
 * проверять `counters.graph.missed` и `counters.errors` в CI как сигнал о битых ссылках или сломанной сборке;
-* сохранять `build.configHash` рядом с артефактами, чтобы знать, какой именно конфиг использовался.
+* сравнивать `counters.entriesPlanned` и `counters.entriesProcessed` — расхождение указывает на сбой обработки части страниц.

--- a/ru/tools/docs/settings.md
+++ b/ru/tools/docs/settings.md
@@ -168,6 +168,9 @@ build -i ./ -o ./build --ignore ./build
  `--add-map-file` | Добавлять создание file.json со всеми путями к документации. По умолчанию выключено.
 ||
 ||
+ `--build-stats` {#build-stats-flag} | Записать рядом с output файл `yfm-build-stats.json` с метриками сборки (длительность, счётчики страниц и ассетов, размер артефактов). Подробнее — в [Статистика сборки](build.md#build-stats). По умолчанию выключено.
+||
+||
  `--disable-csp` | Отключить добавление мета-тега [Content-Security-Policy](../../guides/csp.md#disable-csp) в сгенерированные HTML-страницы. По умолчанию включено.
 ||
 ||


### PR DESCRIPTION
## Summary
Documents the new `--build-stats` CLI flag (introduced in `diplodoc-platform/cli#1905`) which writes a `yfm-build-stats.json` file alongside the build output with diagnostic and CI-friendly metrics.

## Changes
- `tools/docs/settings.md` (RU + EN) — adds a row for `--build-stats` next to `--add-map-file`, with a link to the detailed section.
- `tools/docs/build.md` (RU + EN) — adds a `Build stats` / `Статистика сборки` section describing the file format (cli / build / counters / output / schemaVersion), an example payload, and typical CI use cases.

## Related
- CLI implementation: https://github.com/diplodoc-platform/cli/pull/1905
