### PR TITLE
fix(yfmlint): utf16 in headers #6545

### DIFF
--- a/en/project/lint.md
+++ b/en/project/lint.md
@@ -70,7 +70,7 @@ log-levels:
   YFM017: 'error'   # Invalid front matter format: duplicated mapping key
   YFM018: 'info'    # Term definition from include
   YFM020: 'warn'    # Invalid yfm directive
-  YFM021: 'warn'    # Non-BMP (UTF-16 surrogate pair) character
+  YFM021: 'warn'    # Empty automatic heading anchor
   YFM022: 'info'    # llms-full.txt max size reached
 
 
@@ -82,6 +82,8 @@ YFM001:
 Rules with the `MD` prefix are provided by the [markdownlint](https://github.com/DavidAnson/markdownlint) library.
 A detailed description of all rules with the `MD` prefix can be found [at the link](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md).
 A detailed description of all rules with the `YFM` prefix can be found [at the link](https://github.com/diplodoc-platform/yfmlint/blob/master/README.md).
+
+YFM021 reports headings whose automatic anchor is empty. It relies on the anchors plugin from `@diplodoc/transform`; Diplodoc CLI and the VS Code extension include this plugin by default.
 
 You can override the logging level in the `.yfmlint` file in the `log-levels` section separately for each rule: `error`, `warn`, `disabled`.
 

--- a/ru/project/lint.md
+++ b/ru/project/lint.md
@@ -70,7 +70,7 @@ log-levels:
   YFM017: 'error'   # Invalid front matter format: duplicated mapping key
   YFM018: 'info'    # Term definition from include
   YFM020: 'warn'    # Invalid yfm directive
-  YFM021: 'warn'    # Non-BMP (UTF-16 surrogate pair) character
+  YFM021: 'warn'    # Empty automatic heading anchor
   YFM022: 'info'    # llms-full.txt max size reached
 
 
@@ -82,6 +82,8 @@ YFM001:
 Правила с префиксом `MD` предоставляются библиотекой [markdownlint](https://github.com/DavidAnson/markdownlint).
 Подробное описание всех правил с префиксом `MD` можно найти [по ссылке](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md).
 Подробное описание всех правил с префиксом `YFM` можно найти [по ссылке](https://github.com/diplodoc-platform/yfmlint/blob/master/README.md).
+
+YFM021 сообщает о заголовках с пустым автоматическим якорем. Правило использует плагин anchors из `@diplodoc/transform`; Diplodoc CLI и расширение для VS Code подключают его по умолчанию.
 
 Вы можете переопределить уровень логирования в файле `.yfmlint` в секции `log-levels` отдельно для каждого правила: `error`, `warn`, `disabled`.
 


### PR DESCRIPTION
## Description

- YFM021 now checks only headings with an empty automatic anchor.
- Regular emoji and Unicode characters no longer trigger unnecessary warnings.
- To fix this, it is suggested to add an explicit anchor `{#section-id}`.
- The default YFM021 level is `warn`.
- The rule alias has been changed to `empty-auto-heading-anchor`.
- VSC and CLI use the same check via the anchors plugin.

Linked:

- https://github.com/diplodoc-platform/transform/pull/1048
- https://github.com/diplodoc-platform/vsc/pull/224
- https://github.com/diplodoc-platform/yfmlint/pull/84